### PR TITLE
deprecate qrztools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # qrztools
 
+# **WARNING:** This library is now deprecated. Use [callsignlookuptools](https://pypi.org/project/callsignlookuptools/) instead.
+
 QRZ API interface in Python
 
 [![PyPI](https://img.shields.io/pypi/v/qrztools)](https://pypi.org/project/qrztools/) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/qrztools) ![PyPI - License](https://img.shields.io/pypi/l/qrztools) [![Documentation Status](https://readthedocs.org/projects/qrztools/badge/?version=latest)](https://qrztools.readthedocs.io/en/latest/?badge=latest)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,6 +2,8 @@
 API Reference
 =============
 
+.. WARNING:: This library is now deprecated. Use `callsignlookuptools <https://pypi.org/project/callsignlookuptools/>`_ instead.
+
 .. highlight:: none
 
 ``qrztools`` allows for both synchronous and asynchronous usage via two main classes, :class:`qrztools.QrzSync` and :class:`qrztools.QrzAsync`.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2,6 +2,8 @@
 CLI Usage
 =========
 
+.. WARNING:: This library is now deprecated. Use `callsignlookuptools <https://pypi.org/project/callsignlookuptools/>`_ instead.
+
 .. highlight:: none
 
 .. NOTE:: To use the CLI, install with the extra ``cli`` (e.g. ``pip install qrztools[cli]``) or otherwise install the library ``rich``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,8 @@
 QRZTools
 ========
 
+.. WARNING:: This library is now deprecated. Use `callsignlookuptools <https://pypi.org/project/callsignlookuptools/>`_ instead.
+
 A QRZ API interface in Python with sync and async support.
 
 .. highlight:: none

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -2,6 +2,8 @@
 Types
 =====
 
+.. WARNING:: This library is now deprecated. Use `callsignlookuptools <https://pypi.org/project/callsignlookuptools/>`_ instead.
+
 .. highlight:: none
 
 .. module:: qrztools.qrztools

--- a/qrztools/__info__.py
+++ b/qrztools/__info__.py
@@ -3,7 +3,7 @@
 
 
 __project__ = "qrztools"
-__summary__ = "QRZ API interface in Python"
+__summary__ = "DEPRECATED - QRZ API interface in Python"
 __webpage__ = "https://qrztools.miaow.io"
 
 __version__ = "1.1.1"

--- a/qrztools/__init__.py
+++ b/qrztools/__init__.py
@@ -8,10 +8,13 @@ Released under the terms of the BSD 3-Clause license.
 """
 
 from importlib.util import find_spec
+from warnings import warn
 
 from .__info__ import __version__  # noqa: F401
 
 from .qrztools import QrzError, QrzCallsignData, QrzDxccData, QrzAbc  # noqa: F401
+
+warn("This library is now deprecated. Use callsignlookuptools instead.", DeprecationWarning, stacklevel=2)
 
 if find_spec("requests"):
     from .qrzsync import QrzSync  # noqa: F401

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 7 - Inactive",
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Fixes #12 

* adds a warning to all documentation, README, and pypi description
* adds `DeprecationWarning` on import:

```py
>>> import qrztools
<stdin>:1: DeprecationWarning: This library is now deprecated. Use callsignlookuptools instead.
```

This PR should not be merged until miaowware/callsignlookuptools 1.0.0 release.